### PR TITLE
Fix MSVC warnings and _m64 behavior on Windows 10

### DIFF
--- a/ktm/interface/complex/icomp_array.h
+++ b/ktm/interface/complex/icomp_array.h
@@ -25,7 +25,7 @@ struct icomp_array<Father, comp<T>> : Father
     using array_type = std::array<T, 2>;
 private:
     template<class F, class C>
-    friend class iarray_util;
+	friend struct iarray_util;
 
     KTM_FUNC array_type& to_array_impl() noexcept
     {

--- a/ktm/interface/complex/icomp_array.h
+++ b/ktm/interface/complex/icomp_array.h
@@ -25,7 +25,7 @@ struct icomp_array<Father, comp<T>> : Father
     using array_type = std::array<T, 2>;
 private:
     template<class F, class C>
-	friend struct iarray_util;
+    friend struct iarray_util;
 
     KTM_FUNC array_type& to_array_impl() noexcept
     {

--- a/ktm/interface/matrix/imat_array.h
+++ b/ktm/interface/matrix/imat_array.h
@@ -26,7 +26,7 @@ struct imat_array<Father, mat<Row, Col, T>> : Father
     using array_type = std::array<vec<Col, T>, Row>;
 private:
     template<class F, class C>
-    friend class iarray_util;
+	friend struct iarray_util;
 
     KTM_FUNC array_type& to_array_impl() noexcept
     {

--- a/ktm/interface/matrix/imat_array.h
+++ b/ktm/interface/matrix/imat_array.h
@@ -26,7 +26,7 @@ struct imat_array<Father, mat<Row, Col, T>> : Father
     using array_type = std::array<vec<Col, T>, Row>;
 private:
     template<class F, class C>
-	friend struct iarray_util;
+    friend struct iarray_util;
 
     KTM_FUNC array_type& to_array_impl() noexcept
     {

--- a/ktm/interface/quaternion/iquat_array.h
+++ b/ktm/interface/quaternion/iquat_array.h
@@ -25,7 +25,7 @@ struct iquat_array<Father, quat<T>> : Father
     using array_type = std::array<T, 4>;
 private:
     template<class F, class C>
-    friend class iarray_util;
+	friend struct iarray_util;
 
     KTM_FUNC array_type& to_array_impl() noexcept
     {

--- a/ktm/interface/quaternion/iquat_array.h
+++ b/ktm/interface/quaternion/iquat_array.h
@@ -25,7 +25,7 @@ struct iquat_array<Father, quat<T>> : Father
     using array_type = std::array<T, 4>;
 private:
     template<class F, class C>
-	friend struct iarray_util;
+    friend struct iarray_util;
 
     KTM_FUNC array_type& to_array_impl() noexcept
     {

--- a/ktm/interface/vector/ivec_array.h
+++ b/ktm/interface/vector/ivec_array.h
@@ -25,7 +25,7 @@ struct ivec_array<Father, vec<N, T>> : Father
     using array_type = std::array<T, N>;
 private:
     template<class F, class C>
-    friend class iarray_util;
+    friend struct iarray_util;
 
     KTM_FUNC array_type& to_array_impl() noexcept
     {

--- a/ktm/interface/vector/ivec_calc.h
+++ b/ktm/interface/vector/ivec_calc.h
@@ -27,7 +27,7 @@ struct ivec_calc<Father, vec<3, T>> : Father
     using Father::child_ptr;
 private:
     template<class F, class C>
-    friend class iarray_add;
+    friend struct iarray_add;
 
     KTM_INLINE vec<3, T> add_impl(const vec<3, T>& y) const noexcept
     {
@@ -63,7 +63,7 @@ private:
     }
     
     template<class F, class C>
-    friend class iarray_mul;
+    friend struct iarray_mul;
 
     KTM_INLINE vec<3, T> mul_impl(const vec<3, T>& y) const noexcept
     {
@@ -92,7 +92,7 @@ private:
     }
 
     template<class F, class C>
-    friend class iarray_madd;
+    friend struct iarray_madd;
 
     KTM_INLINE vec<3, T> madd_impl(const vec<3, T>& y, const vec<3, T>& z) const noexcept
     {
@@ -108,7 +108,7 @@ private:
     }
 
     template<class F, class C>
-    friend class iarray_add_scalar;
+    friend struct iarray_add_scalar;
 
     KTM_INLINE vec<3, T> add_scalar_impl(T scalar) const noexcept
     {
@@ -137,7 +137,7 @@ private:
     }
 
     template<class F, class C>
-    friend class iarray_mul_scalar;
+    friend struct iarray_mul_scalar;
 
     KTM_INLINE vec<3, T> mul_scalar_impl(T scalar) const noexcept
     {
@@ -166,7 +166,7 @@ private:
     }
 
     template<class F, class C>
-    friend class iarray_madd_scalar;
+	friend struct iarray_madd_scalar;
 
     KTM_INLINE vec<3, T> madd_scalar_impl(const vec<3, T>& y, T scalar) const noexcept
     {

--- a/ktm/simd/skv.h
+++ b/ktm/simd/skv.h
@@ -20,8 +20,8 @@ namespace skv
     typedef float32x4_t fv4;
     typedef int32x4_t sv4;
 #elif KTM_SIMD_ENABLE(KTM_SIMD_SSE)
-    typedef __m64 fv2;
-    typedef __m64 sv2;
+    typedef uint64_t fv2;
+    typedef uint64_t sv2;
     typedef __m128 fv4;
     #if KTM_SIMD_ENABLE(KTM_SIMD_SSE2)
        typedef __m128i sv4; 


### PR DESCRIPTION
### Description:
This PR addresses two issues:

1. **Resolved MSVC warnings:** Adjusted mismatched `class` and `struct` definitions to prevent MSVC from complaining during compilation.
2. **Fixed `_m64` behavior:** Corrected an inconsistency observed when using `_m64` on Windows 10.

These changes improve compatibility and ensure more predictable behavior on Windows platforms.
